### PR TITLE
License and podspec

### DIFF
--- a/CFIFrostedOverlayView.podspec
+++ b/CFIFrostedOverlayView.podspec
@@ -1,0 +1,28 @@
+Pod::Spec.new do |s|
+  s.name         = "CFIFrostedOverlayView"
+  s.version      = "0.0.1"
+  s.summary      = "A view that renders its superview with a gaussian blur like iOS 7's Control Center."
+
+  s.description  = <<-DESC
+  		   A view that renders its superview with a gaussian blur like iOS 7's Control Center.
+                   DESC
+
+  s.homepage     = "https://github.com/CodaFi/CFIFrostedOverlayView"
+  s.screenshots  = "https://raw.github.com/CodaFi/CFIFrostedOverlayView/master/Artwork/Screen%20Shot%202013-06-16%20at%201.50.35%20PM.png"
+
+  s.license      = { :type => 'MIT', :file => 'LICENSE' }
+  s.author       = { "Robert Widmann" => "devteam.codafi@gmail.com" }
+
+  s.ios.deployment_target = '7.0'
+#  s.osx.deployment_target = '10.7'
+
+  s.source       = { :git => "https://github.com/CodaFi/CFIFrostedOverlayView.git", :tag => "0.0.1" }
+  s.source_files  = 'CFIFrostedOverlayView.{h,m}'
+
+  s.public_header_files = 'CFIFrostedOverlayView.h'
+  s.requires_arc = true
+
+  # s.xcconfig = { 'HEADER_SEARCH_PATHS' => '$(SDKROOT)/usr/include/libxml2' }
+  s.dependency 'GPUImage', '~> 0.1.1'
+
+end

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) [year] [fullname]
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
Adds the MIT license file and a podspec which I will submit to the main specs repo if you can tag the repo.
